### PR TITLE
feat(proposition): add API for creating propositions

### DIFF
--- a/src/main/java/org/_iir/backend/modules/proposition/Proposition.java
+++ b/src/main/java/org/_iir/backend/modules/proposition/Proposition.java
@@ -1,5 +1,8 @@
 package org._iir.backend.modules.proposition;
 
+import java.time.LocalDateTime;
+import java.util.Date;
+
 import org._iir.backend.modules.demande.Demande;
 import org._iir.backend.modules.prestataire.Prestataire;
 
@@ -19,12 +22,30 @@ public class Proposition {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Double tarifPropose;
-    private String disponibiliteProposee;
+    private String description;
+    private Double tarifProposer;
+    @Temporal(TemporalType.DATE)
+    private Date disponibiliteProposer;
 
-    @ManyToOne
+    @ManyToOne()
+    @JoinColumn(name = "demande_id")
     private Demande demande;
 
     @ManyToOne
+    @JoinColumn(name = "prestataire_id")
     private Prestataire prestataire;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    private void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    private void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/org/_iir/backend/modules/proposition/PropositionController.java
+++ b/src/main/java/org/_iir/backend/modules/proposition/PropositionController.java
@@ -1,7 +1,23 @@
 package org._iir.backend.modules.proposition;
 
-import org.springframework.web.bind.annotation.RestController;
+import org._iir.backend.modules.proposition.dto.PropositionDto;
+import org._iir.backend.modules.proposition.dto.PropositionReq;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 @RestController
+@RequiredArgsConstructor
 public class PropositionController {
+    
+        private final PropositionService service;
+    
+        @PostMapping("/api/proposition")
+        public ResponseEntity<PropositionDto> create(@RequestBody @Valid PropositionReq request) {
+            PropositionDto dto = service.create(request);
+            return ResponseEntity.status(HttpStatus.CREATED).body(dto);
+        }
 }

--- a/src/main/java/org/_iir/backend/modules/proposition/PropositionMapper.java
+++ b/src/main/java/org/_iir/backend/modules/proposition/PropositionMapper.java
@@ -1,0 +1,40 @@
+package org._iir.backend.modules.proposition;
+
+import org._iir.backend.interfaces.IMapper;
+import org._iir.backend.modules.proposition.dto.DemandeDto;
+import org._iir.backend.modules.proposition.dto.PrestataireDto;
+import org._iir.backend.modules.proposition.dto.PropositionDto;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class PropositionMapper implements IMapper<Proposition, PropositionDto> {
+    
+    @Override
+    public Proposition toEntity(PropositionDto dto) {
+
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'toEntity'");
+    }
+
+    @Override
+    public PropositionDto toDTO(Proposition entity) {
+        return PropositionDto.builder()
+                .id(entity.getId())
+                .description(entity.getDescription())   
+                .tarifProposer(entity.getTarifProposer())
+                .dateDisponible(entity.getDisponibiliteProposer())
+                .demandeDto(DemandeDto.builder()
+                        .id(entity.getDemande().getId())
+                        .description(entity.getDemande().getDescription())
+                        .dateDisponible(entity.getDemande().getDateDisponible())
+                        .build())
+                .prestataireDto(PrestataireDto.builder()
+                        .id(entity.getPrestataire().getId())
+                        .email(entity.getPrestataire().getEmail())
+                        .build())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/org/_iir/backend/modules/proposition/PropositionService.java
+++ b/src/main/java/org/_iir/backend/modules/proposition/PropositionService.java
@@ -1,7 +1,80 @@
 package org._iir.backend.modules.proposition;
 
+import java.util.List;
+
+import org._iir.backend.exception.OwnNotFoundException;
+import org._iir.backend.interfaces.IService;
+import org._iir.backend.modules.demande.Demande;
+import org._iir.backend.modules.demande.DemandeRepository;
+import org._iir.backend.modules.prestataire.Prestataire;
+import org._iir.backend.modules.proposition.dto.PropositionDto;
+import org._iir.backend.modules.proposition.dto.PropositionReq;
+import org._iir.backend.modules.user.UserService;
+import org.hibernate.validator.internal.util.logging.LoggerFactory;
+import org.slf4j.Logger;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 @Service
-public class PropositionService {
+@RequiredArgsConstructor
+@Slf4j
+public class PropositionService implements IService<Proposition, PropositionDto, PropositionReq, PropositionReq, Long> {
+    // Logger
+    // private final Logger logger = LoggerFactory.getLogger(getClass().getName());
+    
+    private final PropositionDao repository;
+    private final PropositionMapper mapper;
+    private final UserService userService;
+    private final DemandeRepository demandeRepository;
+    
+
+    public PropositionDto create(PropositionReq request) {
+        Demande demande = demandeRepository.findById(request.demandeId())
+            .orElseThrow(() ->{
+                log.error("Demande with id {} not found",request.demandeId());
+                return new OwnNotFoundException("Demande not exists");
+            });
+        
+        Prestataire prestataire = (Prestataire) userService.getAuthenticatedUser();
+
+
+        Proposition proposition = Proposition.builder()
+            .tarifProposer(request.tarifProposer())
+            .description(request.description())
+            .disponibiliteProposer(request.dateDisponibilite())
+            .demande(demande)
+            .prestataire(prestataire)
+            .build();
+
+        return mapper.toDTO(repository.save(proposition));
+    }
+
+    @Override
+    public PropositionDto update(PropositionReq req, Long id) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void delete(Long id) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public PropositionDto findById(Long id) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public List<PropositionDto> findList() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public Page<PropositionDto> findPage(Pageable pageable) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 }

--- a/src/main/java/org/_iir/backend/modules/proposition/dto/DemandeDto.java
+++ b/src/main/java/org/_iir/backend/modules/proposition/dto/DemandeDto.java
@@ -1,0 +1,27 @@
+package org._iir.backend.modules.proposition.dto;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+
+import org._iir.backend.modules.demande.dto.DemandeurDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class DemandeDto {
+    private Long id;
+    private String service;
+    private String description;
+    private Date dateDisponible;
+    private String lieu;
+    private DemandeurDTO demandeur;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/_iir/backend/modules/proposition/dto/PrestataireDto.java
+++ b/src/main/java/org/_iir/backend/modules/proposition/dto/PrestataireDto.java
@@ -1,0 +1,16 @@
+package org._iir.backend.modules.proposition.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class PrestataireDto {
+    private Long id;
+    private String email;
+    
+}

--- a/src/main/java/org/_iir/backend/modules/proposition/dto/PropositionDto.java
+++ b/src/main/java/org/_iir/backend/modules/proposition/dto/PropositionDto.java
@@ -1,0 +1,24 @@
+package org._iir.backend.modules.proposition.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PropositionDto {
+    private Long id;
+    private String description;
+    private Double tarifProposer;
+    private Date dateDisponible;
+    private DemandeDto demandeDto;
+    private PrestataireDto prestataireDto;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/_iir/backend/modules/proposition/dto/PropositionReq.java
+++ b/src/main/java/org/_iir/backend/modules/proposition/dto/PropositionReq.java
@@ -1,0 +1,25 @@
+package org._iir.backend.modules.proposition.dto;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+public record PropositionReq(
+    @NotBlank(message = "Description must not be blank.")
+    @Size(max = 500, message = "Description must not exceed 500 characters.")
+    String description,
+    @NotNull(message = "Price must not be null.")
+    @Positive(message = "Price must be positive.")
+    double tarifProposer,
+    @NotNull(message = "Date de disponibilité must not be null.")
+    @Future(message = "Date de disponibilité must be a future date.")
+    Date dateDisponibilite,
+    Long demandeId
+) {
+
+}


### PR DESCRIPTION
- Updated  entity with necessary modifications.
- Enhanced  to handle new proposition creation logic.
- Introduced  for DTO and entity mapping.
- Updated  to include business logic for creating propositions.
- Added new DTOs:
  -  for incoming request validation.
  -  for proposition representation.
  -  and  for related data.